### PR TITLE
Fix trl_memory_train.py script

### DIFF
--- a/trl_memory_train.py
+++ b/trl_memory_train.py
@@ -4,17 +4,17 @@ Minimal continued-pretraining script for persona memory JSONL produced by system
 - Expects rows like: {"text": "<<SYSTEM_PERSONA>>\\n...\\n\\n<<MEMORY>>\\n..."}
 - Packs sequences to block_size and trains causal LM.
 
-Usage (PowerShell):
-  python .\\trl_memory_train.py `
-    --model-id meta-llama/Llama-3.1-8B `
-    --data "C:\\Users\\azinv\\Documents\\nate_wolfe\\dataset-memory.jsonl" `
-    --out ".\\llama3-nate-memory" `
-    --block-size 4096 `
-    --epochs 1 `
-    --lr 2e-5 `
-    --batch 1 `
-    --grad-accum 8 `
-    --fp16
+Usage:
+  python trl_memory_train.py \
+    --model-id nate_storm_consciousness_v5 \
+    --data "/workspace/dataset-memory.jsonl" \
+    --out "./nate_storm_consciousness_memory_v1" \
+    --block-size 4096 \
+    --epochs 1 \
+    --lr 2e-5 \
+    --batch 1 \
+    --grad-accum 8 \
+    --bf16
 """
 from __future__ import annotations
 import argparse


### PR DESCRIPTION
Update `trl_memory_train.py` to use the correct dataset path, SFT-trained model, bf16 precision, and output directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-0911018f-e916-4368-a5dd-0641f7a54bd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0911018f-e916-4368-a5dd-0641f7a54bd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

